### PR TITLE
v1.5.4: add GitHub Pages concurrency group to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ name: Build and Deploy Telar Site
 # build time. Sites without audio objects skip audio tool installation and
 # processing entirely — zero friction for image-only sites.
 #
-# Version: v1.5.0
+# Version: v1.5.4
 
 on:
   push:
@@ -54,6 +54,18 @@ permissions:
   contents: write
   pages: write
   id-token: write
+
+# GitHub Pages allows only one in-progress deployment per repository. When a
+# site is pushed to several times in quick succession (for example, the Telar
+# Compositor's site-creation flow fires two commits and a manual run within the
+# same second), the extra build runs would otherwise race on the single Pages
+# deployment slot — the losers fail their "Deploy to GitHub Pages" step and the
+# owner gets a spurious build-failure email, even though a sibling run deploys
+# the site correctly. Grouping the runs and cancelling superseded ones keeps the
+# newest commit's build as the single winner with no failure noise.
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build-and-deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Telar will be documented in this file.
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-06-29
+
+CI/build fix release. Adds a GitHub Pages concurrency group to the build workflow so rapid successive builds of the same repository no longer race on Pages' one-deployment-per-repo limit. CI only — no content, schema, or configuration changes. Upgrade in place or simply redeploy.
+
+### Fixed
+
+- **Spurious "build failed" emails on rapid successive builds.** GitHub Pages allows only one in-progress deployment per repository, so when several builds started within the same second (for example, when a new site is created and multiple commits plus a manual run land together) the losing runs failed their "Deploy to GitHub Pages" step and emailed the owner, even though the site deployed correctly. Build runs are now grouped per branch with a `concurrency` setting and superseded runs are cancelled, so the newest build wins cleanly with no failure noise.
+
+### Notes
+
+- The only changed framework file is `.github/workflows/build.yml`. The Telar Compositor updates it automatically on upgrade; sites upgrading via the "Upgrade Telar" Actions workflow or locally must add the `concurrency` block by hand, since GitHub does not allow automated upgrades to modify workflow files (see the release notes for the exact snippet).
+
 ## [1.5.3] - 2026-06-23
 
 Internationalization fix release. Built-in interface text that still showed in English on Spanish-language sites (`telar_language: es`) now follows the site language. Display only — no content, schema, or configuration changes. Upgrade in place or simply redeploy.

--- a/_config.yml
+++ b/_config.yml
@@ -116,8 +116,8 @@ show_drafts: false
 
 # Telar Settings (version information)
 telar:
-  version: "1.5.3"
-  release_date: "2026-06-23"
+  version: "1.5.4"
+  release_date: "2026-06-29"
 
 # Plugins
 plugins:

--- a/migration.json
+++ b/migration.json
@@ -1,19 +1,27 @@
 {
   "schema_version": 1,
-  "from_version": "1.5.1",
-  "to_version": "1.5.2",
-  "description": "Validation banner message fixes and homepage warning localisation; display-only",
+  "from_version": "1.5.3",
+  "to_version": "1.5.4",
+  "description": "Add a GitHub Pages concurrency group to the build workflow so rapid successive builds don't race; no content changes",
   "operations": [],
   "manual_steps": {
     "en": [
       {
-        "description": "**No action needed.** This is a display-only fix.\n\n- **If you use GitHub Pages:** your site picks up the fix automatically the next time it builds.\n- **If you work with your site locally:** just rebuild your site to use the updated warning messages.",
+        "description": "**If you use the Telar Compositor: no action needed.** The Compositor updates your build workflow automatically when it upgrades your site.",
+        "doc_url": "https://telar.org/docs"
+      },
+      {
+        "description": "**If you use GitHub Pages with the \"Upgrade Telar\" workflow, or work locally:** GitHub does not allow the automated upgrade to change workflow files, so your build workflow is not updated for you. Add the following block to `.github/workflows/build.yml`, just before the `jobs:` line (or recopy the file from the latest template):\n\n```yaml\nconcurrency:\n  group: \"pages-${{ github.ref }}\"\n  cancel-in-progress: true\n```\n\nUntil you do, your site keeps building and deploying correctly — you may just get an occasional spurious \"build failed\" email when two builds start at the same time.",
         "doc_url": "https://telar.org/docs"
       }
     ],
     "es": [
       {
-        "description": "**No se requiere ninguna acción.** Esta corrección solo afecta los mensajes que se muestran en pantalla.\n\n- **Si usas GitHub Pages:** tu sitio aplica la corrección automáticamente la próxima vez que se construye.\n- **Si trabajas con tu sitio localmente:** solo vuelve a construir el sitio para usar los mensajes de advertencia actualizados.",
+        "description": "**Si usas el Compositor de Telar: no tienes que hacer nada.** El Compositor actualiza por ti el flujo de trabajo de construcción cuando actualiza tu sitio.",
+        "doc_url": "https://telar.org/guia"
+      },
+      {
+        "description": "**Si usas GitHub Pages con el flujo de trabajo \"Upgrade Telar\", o trabajas localmente:** GitHub no permite que la actualización automática modifique los archivos de flujo de trabajo, así que el tuyo no se actualiza solo. Agrega el siguiente bloque a `.github/workflows/build.yml`, justo antes de la línea `jobs:` (o vuelve a copiar el archivo desde la plantilla más reciente):\n\n```yaml\nconcurrency:\n  group: \"pages-${{ github.ref }}\"\n  cancel-in-progress: true\n```\n\nMientras tanto, tu sitio se sigue construyendo y publicando sin problemas; solo podrías recibir de vez en cuando un correo de «build failed» que no corresponde a una falla real, cuando dos ejecuciones empiezan al mismo tiempo.",
         "doc_url": "https://telar.org/guia"
       }
     ]

--- a/scripts/migrations/v153_to_v154.py
+++ b/scripts/migrations/v153_to_v154.py
@@ -1,0 +1,116 @@
+"""
+Migration from v1.5.3 to v1.5.4.
+
+CI/build patch. The GitHub Actions build workflow gains a `concurrency` group
+so rapid successive builds of the same repository no longer race on GitHub
+Pages' one-in-progress-deployment-per-repo limit. Before this, several build
+runs starting within the same second (for example, when the Telar Compositor
+creates a new site and pushes two commits plus a manual run together) raced for
+the single Pages deployment slot; the losers failed their "Deploy to GitHub
+Pages" step and emailed the owner a spurious "build failed" notice, even though
+a sibling run deployed the site correctly.
+
+The only changed framework file is `.github/workflows/build.yml`. GitHub does
+not permit the `GITHUB_TOKEN` used by the in-Actions upgrade to modify files
+under `.github/workflows/`, so this migration cannot install the new workflow
+itself — it would make the upgrade pull request fail. The change therefore
+reaches sites two other ways:
+
+  - The Telar Compositor replaces framework files (including the workflow) via
+    its own tree-diff on upgrade, so Compositor-managed sites get it
+    automatically.
+  - Sites upgrading through the "Upgrade Telar" Actions workflow, or locally,
+    add the `concurrency` block by hand (see the manual step below) or recopy
+    `build.yml` from the latest template.
+
+This migration carries no user-content transforms — the story step schema, CSV
+formats, configuration keys, and language packs are all unchanged. Its job is
+to keep the strict upgrade chain intact (v1.5.3 -> v1.5.4) so upgrade.py reaches
+the latest version and stamps it, and to surface the manual workflow step.
+
+The version stamp (telar.version -> 1.5.4) is not written here. upgrade.py
+applies it once after every migration step succeeds, so a failed step can never
+leave the site stamped as a version it is not running.
+
+Version: v1.5.4
+"""
+
+from typing import Dict, List
+
+from .base import BaseMigration, ChangeRecord
+
+
+class Migration153to154(BaseMigration):
+    """Migration from v1.5.3 to v1.5.4 — build-workflow concurrency group; no content changes."""
+
+    from_version = "1.5.3"
+    to_version = "1.5.4"
+    description = "Add a GitHub Pages concurrency group to the build workflow; no content changes"
+
+    def check_applicable(self) -> bool:
+        return True
+
+    def apply(self) -> List[ChangeRecord]:
+        # No framework files are installed: the only change is the build
+        # workflow, which GITHUB_TOKEN cannot write. There are no config, CSV,
+        # directory, or cleanup changes. Record the workflow update as a soft
+        # item so it surfaces in the upgrade summary as a manual step, and let
+        # upgrade.py stamp the version once the chain completes.
+        return [
+            ChangeRecord(
+                description=(
+                    "Build workflow concurrency group: add the `concurrency` block to "
+                    ".github/workflows/build.yml by hand (or recopy the file). The "
+                    "in-Actions upgrade cannot modify workflow files; the Telar "
+                    "Compositor applies it automatically. See the manual step below."
+                ),
+            ),
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Manual steps (bilingual)
+    # ------------------------------------------------------------------ #
+
+    def get_manual_steps(self) -> List[Dict[str, str]]:
+        lang = self._detect_language()
+        return self._get_manual_steps_es() if lang == 'es' else self._get_manual_steps_en()
+
+    def _get_manual_steps_en(self) -> List[Dict[str, str]]:
+        return [
+            {
+                'description': '''**If you use the Telar Compositor: no action needed.** The Compositor updates your build workflow automatically when it upgrades your site.''',
+                'doc_url': 'https://telar.org/docs'
+            },
+            {
+                'description': '''**If you use GitHub Pages with the "Upgrade Telar" workflow, or work locally:** GitHub does not allow the automated upgrade to change workflow files, so your build workflow is not updated for you. Add the following block to `.github/workflows/build.yml`, just before the `jobs:` line (or recopy the file from the latest template):
+
+```yaml
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
+```
+
+Until you do, your site keeps building and deploying correctly — you may just get an occasional spurious "build failed" email when two builds start at the same time.''',
+                'doc_url': 'https://telar.org/docs'
+            },
+        ]
+
+    def _get_manual_steps_es(self) -> List[Dict[str, str]]:
+        return [
+            {
+                'description': '''**Si usas el Compositor de Telar: no tienes que hacer nada.** El Compositor actualiza por ti el flujo de trabajo de construcción cuando actualiza tu sitio.''',
+                'doc_url': 'https://telar.org/guia'
+            },
+            {
+                'description': '''**Si usas GitHub Pages con el flujo de trabajo "Upgrade Telar", o trabajas localmente:** GitHub no permite que la actualización automática modifique los archivos de flujo de trabajo, así que el tuyo no se actualiza solo. Agrega el siguiente bloque a `.github/workflows/build.yml`, justo antes de la línea `jobs:` (o vuelve a copiar el archivo desde la plantilla más reciente):
+
+```yaml
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
+```
+
+Mientras tanto, tu sitio se sigue construyendo y publicando sin problemas; solo podrías recibir de vez en cuando un correo de «build failed» que no corresponde a una falla real, cuando dos ejecuciones empiezan al mismo tiempo.''',
+                'doc_url': 'https://telar.org/guia'
+            },
+        ]

--- a/scripts/upgrade.py
+++ b/scripts/upgrade.py
@@ -75,10 +75,11 @@ from migrations.v140_to_v150 import Migration140to150
 from migrations.v150_to_v151 import Migration150to151
 from migrations.v151_to_v152 import Migration151to152
 from migrations.v152_to_v153 import Migration152to153
+from migrations.v153_to_v154 import Migration153to154
 
 
 # Latest version
-LATEST_VERSION = "1.5.3"
+LATEST_VERSION = "1.5.4"
 
 # All available migrations in order
 MIGRATIONS = [
@@ -114,6 +115,7 @@ MIGRATIONS = [
     Migration150to151,
     Migration151to152,
     Migration152to153,
+    Migration153to154,
 ]
 
 


### PR DESCRIPTION
## Summary

CI/build fix. Adds a `concurrency` group to `.github/workflows/build.yml` so rapid successive builds of the same repository no longer race on GitHub Pages' one-in-progress-deployment-per-repo limit. No content, schema, or configuration changes.

## Problem

GitHub Pages allows only one in-progress deployment per repository. When a site receives several pushes — or a push plus a `workflow_dispatch` — within the same second, multiple build runs start at once and race for the single Pages deployment slot. The losing runs fail their "Deploy to GitHub Pages" step with:

```
HttpError: Deployment request failed for <sha> due to in progress deployment.
Please cancel <other-sha> first or wait for it to complete.
```

and the owner gets a spurious "build failed" email even though a sibling run deploys the site correctly. This is most visible when a new site is created (several commits plus a manual run land together), but it affects any site pushed to in quick succession.

## Fix

```yaml
concurrency:
  group: "pages-${{ github.ref }}"
  cancel-in-progress: true
```

Build runs are grouped per ref and superseded runs are cancelled, so the newest commit's build is the single winner with no failure noise. Cancelling (rather than queueing) is intentional: when several commits land together the latest one is the corrected version, so the newest build should win and cancelled runs send no failure email.

## Changes

- `.github/workflows/build.yml` — `concurrency` block + version header → v1.5.4
- `scripts/upgrade.py` — `LATEST_VERSION` 1.5.3 → 1.5.4, register the new migration
- `scripts/migrations/v153_to_v154.py` — chain link (no content transforms); carries the manual workflow step
- `CHANGELOG.md`, `_config.yml`, `migration.json` — version and release metadata

## Migration impact

The only changed framework file is the workflow itself, which the in-Actions upgrade cannot modify (GitHub blocks the `GITHUB_TOKEN` from writing `.github/workflows/`). So:

- **Compositor-managed sites** get the new workflow automatically (framework-file tree-diff on upgrade).
- **Sites upgrading via the "Upgrade Telar" Actions workflow or locally** add the block by hand — surfaced as a manual step in the upgrade summary.

## Testing

- **Race reproduced with the fix in place** on a test repo: three overlapping runs (one push + two manual) → two superseded runs **cancelled** (not failed), newest run **succeeded and deployed**, no failure email.
- **Full upgrade on a clean v1.5.3 site**: migration applied → data regenerated → `_config.yml` stamped to 1.5.4 → manual workflow step surfaced in `UPGRADE_SUMMARY.md`.
