### PR TITLE
v1.6.1 — Upgrade-chain repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Telar will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-11
+
+Upgrade-tooling fix release. The v1.6.0 upgrade could not actually be applied: the upgrade script never registered the v1.6.0 migration, so direct upgrade runs stopped at v1.5.4 while reporting success — and the release was missing the verified tooling package the "Upgrade Telar" workflow downloads, so workflow runs failed before making any changes. Both are fixed; upgrading to v1.6.1 applies everything v1.6.0 contained. No site content, configuration, or display changes.
+
+### Fixed
+
+- **Upgrade chain repaired.** `scripts/upgrade.py` now registers the v1.5.4 → v1.6.0 migration (the migration itself shipped with v1.6.0 but was never wired in) and the new v1.6.0 → v1.6.1 step. Upgrades from any earlier version now run through to v1.6.1 and stamp the version they actually installed.
+- **Verified tooling package published.** The `telar-scripts-v1.6.1.tar.gz` release asset and its checksum, which the "Upgrade Telar" workflow requires since v1.5.0, ship with this release (v1.6.0 shipped without them, so the workflow failed closed before touching any site).
+
+### Notes
+
+- If an upgrade run reported success but left your site at v1.5.4, run the upgrade again — the chain now continues through to v1.6.1. If the "Upgrade Telar" workflow failed with a download error, that was this bug.
+- No site was ever left broken or half-upgraded: the workflow path failed before starting, and the direct path completed a valid upgrade to v1.5.4.
+
 ## [1.6.0] - 2026-07-10
 
 Code health release. Housekeeping across the whole framework — verified dead-code removal, consolidation of duplicated logic, honest labelling of generated vs source files — plus a rebuilt private-stories pipeline, a localization sweep, and a long tail of fixes. Framework files and language packs upgrade automatically; one manual step is required for sites that use private stories (see Notes).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A minimal-computing framework that weaves together IIIF images, audio, video, an
 
 ---
 
-> **⚠️ Beta Release - v1.6.0**
+> **⚠️ Beta Release - v1.6.1**
 > This is a beta release for testing and feedback. For detailed documentation, visit **[telar.org/docs](https://telar.org/docs)**.
 
 > **Warning:** If upgrading from v0.3.4 or earlier, see the [Upgrading Telar Guide](https://telar.org/docs/2-workflows/3-upgrading/) for instructions.
@@ -146,7 +146,7 @@ Un marco de computación mínima que entreteje imágenes IIIF, audio, video y te
 
 ---
 
-> **⚠️ Versión Beta - v1.6.0**
+> **⚠️ Versión Beta - v1.6.1**
 > Esta es una versión beta para pruebas y retroalimentación. Para documentación detallada, visita **[telar.org/guia](https://telar.org/guia)**.
 
 > **Advertencia:** Si estás actualizando desde v0.3.4 o anterior, consulta la [Guía de Actualización de Telar](https://telar.org/guia/flujos-de-trabajo/actualizacion/) para obtener instrucciones.

--- a/_config.yml
+++ b/_config.yml
@@ -116,8 +116,8 @@ show_drafts: false
 
 # Telar Settings (version information)
 telar:
-  version: "1.6.0"
-  release_date: "2026-07-10"
+  version: "1.6.1"
+  release_date: "2026-07-11"
 
 # Plugins
 plugins:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telar",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A minimal-computing framework for weaving IIIF images, audio, video, and texts into layered visual narratives.",
   "private": true,
   "license": "MIT",

--- a/scripts/migrations/v160_to_v161.py
+++ b/scripts/migrations/v160_to_v161.py
@@ -1,0 +1,95 @@
+"""
+Migration from v1.6.0 to v1.6.1.
+
+Upgrade-tooling patch. v1.6.0 shipped scripts/migrations/v154_to_v160.py
+without registering it in scripts/upgrade.py — the import block, the
+LATEST_VERSION constant, and the MIGRATIONS list are three hand-synced
+places with no auto-discovery, and only two of the three were updated. The
+result: LATEST_VERSION was left at "1.5.4" and Migration154to160 was never
+imported or appended to MIGRATIONS, so upgrades silently stopped at 1.5.4 —
+reporting success — even though the migration file itself was correct. v1.6.1 wires
+both omissions in: Migration154to160 is now imported and appended, and
+Migration160to161 (this migration) is imported and appended immediately
+after it, with LATEST_VERSION set to "1.6.1".
+
+This is a tooling-only patch — no layout, include, style, script, or
+language-pack file changes, no `_config.yml` key changes, and no CSV/story
+schema changes. Existing stories, objects, and configuration keep working
+without edits.
+
+Per the established convention for this upgrade engine (documented in every
+migration since v1.4.0->v1.5.0: upgrade.py, the migrations package, base.py,
+and messages.py are excluded from FRAMEWORK_FILES and ship out of band, via
+the verified release tarball, rather than through a running migration's own
+fetch/write step), this migration does not re-fetch or rewrite upgrade.py or
+itself. By the time any migration in the chain executes, the site is already
+running the target version's engine code — that engine code is exactly what
+this migration's own fix lives in, and it reaches a site the same way every
+other engine change has: as part of the v1.6.1 release, not as a
+FRAMEWORK_FILES entry. There is nothing else for this migration to change on
+a site, so apply() only records that the fix is internal to the upgrade
+tooling.
+
+The version stamp (telar.version -> 1.6.1) is not written here. upgrade.py
+applies it once after every migration step succeeds, so a failed step can
+never leave the site stamped as a version it is not running.
+
+Version: v1.6.1
+"""
+
+from typing import Dict, List
+
+from .base import BaseMigration, ChangeRecord, ChangeStatus
+
+
+class Migration160to161(BaseMigration):
+    """Migration from v1.6.0 to v1.6.1 — fix the upgrade-chain wiring gap left by v1.6.0; tooling-only."""
+
+    from_version = "1.6.0"
+    to_version = "1.6.1"
+    description = "Register the missing v1.5.4 -> v1.6.0 migration and repair the upgrade chain; tooling-only, no site changes"
+
+    def check_applicable(self) -> bool:
+        return True
+
+    def apply(self) -> List[ChangeRecord]:
+        # No framework files, directories, config, or CSV changes: the entire
+        # fix is the upgrade.py registration wiring, which ships with the
+        # engine itself rather than through a site-facing file write. Record
+        # this as a single informational, already-applied change so it is
+        # visible in UPGRADE_SUMMARY.md without implying anything to install.
+        return [
+            ChangeRecord(
+                description=(
+                    "Upgrade-chain wiring fix (internal): the v1.5.4 -> v1.6.0 migration "
+                    "is now registered in scripts/upgrade.py, so upgrades starting below "
+                    "v1.6.0 no longer stop early at 1.5.4. No files in this site changed."
+                ),
+                status=ChangeStatus.APPLIED,
+                severity="soft",
+            ),
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Manual steps (bilingual)
+    # ------------------------------------------------------------------ #
+
+    def get_manual_steps(self) -> List[Dict[str, str]]:
+        lang = self._detect_language()
+        return self._get_manual_steps_es() if lang == 'es' else self._get_manual_steps_en()
+
+    def _get_manual_steps_en(self) -> List[Dict[str, str]]:
+        return [
+            {
+                'description': '''**No action needed.** v1.6.1 only fixes the upgrade tooling itself (a missing registration that made upgrades stop at v1.5.4 and report success, instead of continuing to v1.6.0); it does not change anything in your site.''',
+                'doc_url': 'https://telar.org/docs'
+            },
+        ]
+
+    def _get_manual_steps_es(self) -> List[Dict[str, str]]:
+        return [
+            {
+                'description': '''**No se requiere ninguna acción.** v1.6.1 solo corrige la propia herramienta de actualización (un registro que faltaba y hacía que las actualizaciones se detuvieran en v1.5.4 y reportaran éxito, en lugar de continuar hasta v1.6.0); no cambia nada en tu sitio.''',
+                'doc_url': 'https://telar.org/guia'
+            },
+        ]

--- a/scripts/upgrade.py
+++ b/scripts/upgrade.py
@@ -21,7 +21,7 @@ UPGRADE_SUMMARY.md file listing every automated change made and any
 manual steps the user still needs to complete. The --dry-run flag
 previews what would happen without making changes.
 
-Version: v1.6.0
+Version: v1.6.1
 
 Usage:
     python scripts/upgrade.py              # Normal upgrade
@@ -79,10 +79,12 @@ from migrations.v150_to_v151 import Migration150to151
 from migrations.v151_to_v152 import Migration151to152
 from migrations.v152_to_v153 import Migration152to153
 from migrations.v153_to_v154 import Migration153to154
+from migrations.v154_to_v160 import Migration154to160
+from migrations.v160_to_v161 import Migration160to161
 
 
 # Latest version — must agree with the import block above and MIGRATIONS below
-LATEST_VERSION = "1.5.4"
+LATEST_VERSION = "1.6.1"
 
 # All available migrations in order — must agree with the import block and
 # LATEST_VERSION above (three hand-synced places, no auto-discovery)
@@ -120,6 +122,8 @@ MIGRATIONS = [
     Migration151to152,
     Migration152to153,
     Migration153to154,
+    Migration154to160,
+    Migration160to161,
 ]
 
 


### PR DESCRIPTION
Patch release. Registers the v1.5.4 → v1.6.0 migration that shipped unwired in v1.6.0 (upgrades stopped at v1.5.4 while reporting success), adds the v1.6.0 → v1.6.1 chain step, and bumps versions. Release publish will also restore the verified tooling assets (telar-scripts tarball + checksums) missing from the v1.6.0 release.

Changes:
- scripts/upgrade.py: register Migration154to160 + Migration160to161, LATEST_VERSION 1.6.1
- scripts/migrations/v160_to_v161.py: new tooling-only migration (no site changes)
- Version bumps: package.json, _config.yml telar.version/release_date, README callouts
- CHANGELOG entry